### PR TITLE
Update System.Console.pas - Allow for use in a GUI app

### DIFF
--- a/Console/System.Console.pas
+++ b/Console/System.Console.pas
@@ -217,6 +217,7 @@ type
     class function ConsoleCursorInfo: TConsoleCursorInfo;
     class function ConsoleRect: TRect;
     class function GetBufferInfo: TConsoleScreenBufferInfo; static;
+    class function CanGetBufferInfo : Boolean; static;
     class function GetConsoleOutputHandle: THandle; static;
     class function ScreenHeight: SmallInt;
     class function ScreenWidth: SmallInt;
@@ -278,7 +279,7 @@ type
 
     // Initialize
     class constructor Create;
-
+    class procedure AttachConsole;
     // Methods
     class procedure Beep(Frequency, Duration: Cardinal); overload; static;
     class procedure Beep; overload; static;
@@ -444,7 +445,7 @@ begin
   Result := (FileType = FILE_TYPE_PIPE) or (FileType = FILE_TYPE_DISK);
 end;
 
-class constructor Console.Create;
+class procedure Console.AttachConsole;
 var
   BufferInfo: TConsoleScreenBufferInfo;
 begin
@@ -475,6 +476,12 @@ begin
   FScreenSize.Y := BufferInfo.srWindow.Bottom - BufferInfo.srWindow.Top + 1;
 end;
 
+class constructor Console.Create;
+begin
+  if Console.CanGetBufferInfo
+  then Console.AttachConsole;
+end;
+
 class procedure Console.DeleteLine;
 begin
   ScrollScreenBuffer(FTextWindow.Left, GetBufferInfo.dwCursorPosition.Y, FTextWindow.Right, FTextWindow.Bottom, -1);
@@ -493,7 +500,7 @@ begin
   if Value.IsArray then
   begin
     if Value.GetArrayLength = 0 then
-      exit('[ø]');
+      exit('[Ã¸]');
 
     Result := '[';
 
@@ -530,6 +537,13 @@ end;
 class function Console.GetBufferHeight: Integer;
 begin
   Result := GetBufferSize.Y;
+end;
+
+class function Console.CanGetBufferInfo : Boolean;
+var
+  dummy : TConsoleScreenBufferInfo;
+begin
+  result := GetConsoleScreenBufferInfo(ConsoleOutputHandle, dummy);
 end;
 
 class function Console.GetBufferInfo: TConsoleScreenBufferInfo;

--- a/Console/System.Console.pas
+++ b/Console/System.Console.pas
@@ -1,4 +1,4 @@
-unit System.Console;
+﻿unit System.Console;
 
 interface
 
@@ -949,7 +949,7 @@ end;
 
 class procedure Console.SetConsoleRect(Rect: TRect);
 begin
-  SetWindowPos(GetConsoleWindow, 0, Rect.Left, Rect.Right, Rect.Top, Rect.Bottom, SWP_SHOWWINDOW);
+  SetWindowPos(GetConsoleWindow, 0, Rect.Left, Rect.Top, Rect.Right, Rect.Bottom, SWP_SHOWWINDOW);
 end;
 
 class procedure Console.SetCursorLeft(const Value: Integer);


### PR DESCRIPTION
First off thanks for creating the project.

The use of a class constructor causes a exception when attempting to use DelphiConsole within a GUI application since referencing Console class in the code causes the class constructor to be called before a console can be allocated dynamically.

My change moves the initialization code to a class procedure Console.AttachConsole which can be called after a console has been allocated.  The class constructor calls Console.CanGetBufferInfo and if successful simply calls Console.AttachConsole otherwise it exits without raising an exception.  This change should be transparent when used in a traditional Delphi console application.

Thank You,
Gordon Hicks


