### PR TITLE
Refactoring of Console.pas

### DIFF
--- a/Console/GUI AND Console APP/GUIAndConsoleApp.dpr
+++ b/Console/GUI AND Console APP/GUIAndConsoleApp.dpr
@@ -8,9 +8,14 @@ uses
 {$R *.res}
 
 begin
-  if Console.AttatchConsole then
+  if Console.IsAttached then
   begin
     Console.WriteLine('Print text in current Console Window.');
+
+    if Console.IsAttached then
+      Console.WriteLine('Attaching twice to the same console returns true')
+    else
+      Console.WriteLine('I''m sad');
   end
   else
   begin // Start GUI


### PR DESCRIPTION
Closes #13 

- Fix numerous warnings from static code analysis
- Remove unused Lock and Release Methods
- Rename **AttatchConsole** to **IsAttached**
- **IsAttached** now returns true, when it is called again and we are already attached to a console
- Move dll function imports into uses section

Remaining FixInsight warnings:
```
[FixInsight Convention] System.Console.pas(924): C101 Method 'Console.MoveBufferArea' is too long (62 lines)
[FixInsight Convention] System.Console.pas(915): C102 Too many parameters in 'Console.MoveBufferArea' (9 parameters)
[FixInsight Convention] System.Console.pas(915): C103 Too many variables in 'Console.MoveBufferArea' (10 variables)
[FixInsight Convention] System.Console.pas(346): C104 Class name 'Console' should start with 'T'
[FixInsight Optimization] System.Console.pas(1039): O804 Method parameter 'Intercept' is declared but never used
```

I have no problems with the first four and wouldn't change anything. We could easily get rid of is the last one, but I don't know if you intended to use 'Intercept' some day.

The only breaking change from my point of view is the change **AttatchConsole/IsAttached**. All examples compile and run, apart from Snake. When running Snake I get a windows message "You need a new app to open this gaming overlay". The same happens with the original. Snake worked a while ago, so I guess some windows update screwed it up.

