### PR TITLE
ResetColor should also reset the current text attributes

### DIFF
--- a/Console/System.Console.pas
+++ b/Console/System.Console.pas
@@ -626,8 +626,8 @@ begin
   Rewrite(Output);
   Rewrite(ErrOutput);
 
-  FTextAttr := GetBufferInfo.wAttributes and $FF;
-  FDefaultTextAttributes := FTextAttr;
+  FDefaultTextAttributes := GetBufferInfo.wAttributes and $FF;
+  FTextAttr := FDefaultTextAttributes;
 
   if not GetConsoleScreenBufferInfo(FStdOut, BufferInfo) then
   begin
@@ -1073,6 +1073,7 @@ end;
 
 class procedure Console.ResetColor;
 begin
+  FTextAttr := FDefaultTextAttributes;
   SetConsoleTextAttribute(FStdOut, FDefaultTextAttributes);
 end;
 

--- a/Console/System.Console.pas
+++ b/Console/System.Console.pas
@@ -408,6 +408,8 @@ type
     class procedure SetOutputEncoding(const Value: DWORD); static;
     class function GetConsoleFont: TCONSOLE_FONT_INFOEX; static;
     class procedure SetConsoleFont(const Value: TCONSOLE_FONT_INFOEX); static;
+    class procedure SetTempColor(aColors: array of TConsoleColor);
+
   public
     // Not implemented
     // class function OpenStandardError(BufferSize: Integer): TStream; overload; static;
@@ -450,6 +452,10 @@ type
     class procedure WriteLine<T>(aValue: T); overload; static;
     class procedure WriteLine(FormatString: String; Args: array of Variant); overload; static;
     class procedure WriteLine; overload; static;
+    class procedure WriteColor<T>(aValue: T; aColors: array of TConsoleColor); overload; static;
+    class procedure WriteColor(Value: Variant; Args: array of const; aColors: array of TConsoleColor); overload; static;
+    class procedure WriteColorLine<T>(aValue: T; aColors: array of TConsoleColor); overload; static;
+    class procedure WriteColorLine(FormatString: String; Args: array of Variant; aColors: array of TConsoleColor); overload; static;
 
     // properties
     class property AutoAllocateConsole : Boolean read FAutoAllocateConsole write FAutoAllocateConsole;
@@ -1315,6 +1321,14 @@ begin
   SetWindowSize(Value, WindowHeight);
 end;
 
+class procedure Console.SetTempColor(aColors: array of TConsoleColor);
+begin
+  if Length(aColors) > 0 then
+    SetForegroundColor(aColors[0]);
+  if Length(aColors) > 1 then
+    SetBackgroundColor(aColors[1]);
+end;
+
 class procedure Console.UpdateConsoleFont(const aFontName: string; aFontSize: Cardinal; aFontFamily: TFontFamily; aFontWeight: TFontWeight);
 var
   CONSOLE_FONT_INFOEX: TCONSOLE_FONT_INFOEX;
@@ -1396,5 +1410,48 @@ class procedure Console.WriteLine;
 begin
   WriteString(sLineBreak);
 end;
+
+class procedure Console.WriteColor(Value: Variant; Args: array of const;
+  aColors: array of TConsoleColor);
+begin
+  SetTempColor(aColors);
+  try
+    Write(Value, Args);
+  finally
+    ResetColor;
+  end;
+end;
+
+class procedure Console.WriteColor<T>(aValue: T; aColors: array of TConsoleColor);
+begin
+  SetTempColor(aColors);
+  try
+    Write(aValue);
+  finally
+    ResetColor;
+  end;
+end;
+
+class procedure Console.WriteColorLine(FormatString: String;
+  Args: array of Variant; aColors: array of TConsoleColor);
+begin
+  SetTempColor(aColors);
+  try
+    WriteLine(FormatString, Args);
+  finally
+    ResetColor;
+  end;
+end;
+
+class procedure Console.WriteColorLine<T>(aValue: T; aColors: array of TConsoleColor);
+begin
+  SetTempColor(aColors);
+  try
+    WriteLine(aValue);
+  finally
+    ResetColor;
+  end;
+end;
+
 
 end.

--- a/Console/WriteLine Test/WriteLineTest.dpr
+++ b/Console/WriteLine Test/WriteLineTest.dpr
@@ -52,6 +52,8 @@ var
   aConsole: Console;
   MyRecord: TMyRecord;
   Obj: TObject;
+  i,r: integer;
+  s: string;
 begin
   try
     WriteHeader('String');
@@ -105,6 +107,21 @@ begin
     finally
       Obj.Free;
     end;
+
+    WriteHeader('Random with color');
+    Randomize;
+    for i := 0 to 5 do
+      begin
+        Console.Write(Format('%d: ', [i]));
+        r := Random(5)-2;
+        s := Format('%2d',[r]);
+        if r <0 then
+          Console.WriteColorLine(s,[TConsoleColor.White, TConsoleColor.Red])
+        else if r=0 then
+          Console.WriteColorLine(s,[TConsoleColor.Yellow])
+        else
+          Console.WriteColorLine(s,[TConsoleColor.Green]);
+      end;
 
     WriteHeader('Record');
     Console.WriteLine(MyRecord);


### PR DESCRIPTION
This may be intended behaviour, but to me it looks like a bug. 

Assume default = white text on black
Steps to reproduce:
* change foreground to yellow and background to blue
* call resetcolor
* change foreground color to green

expected result: green on black
current result: green on blue